### PR TITLE
add error codes for unsupported value and invalid terminals configuration

### DIFF
--- a/Source/Custom Device Support/Docs/ballardMILSTD1553-errors.txt
+++ b/Source/Custom Device Support/Docs/ballardMILSTD1553-errors.txt
@@ -18,4 +18,7 @@ Imported parameters overlap. Configure each parameter with a unique bit range wi
 <nierror code="-732354">
 Unsupported value. Compare the imported value to the published schema.
 </nierror>
+<nierror code="-732355">
+The address (terminal configuration) is not consistent with the message type. 'RT to BC' messages must define one address with 'Tx' direction. 'BC to RT' messages must define one address with 'Rx' direction. 'MC' messages must define one address with direction.'RT to RT' messages must define two addresses, one with 'Tx' direction and one with 'Rx' direction.
+</nierror>
 </nidocument>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds error code -732354 for unsupported values which could happen if the configuration file does not comply with the schema.
Adds error code -732355 for invalid terminal configuration given the message type.

### Why should this Pull Request be merged?

Unique error codes and descriptions help users debug their custom device when they observe unexpected behavior.

### What testing has been done?

none
