### PR TITLE
Add description for each status channel - Fixes #121

### DIFF
--- a/Source/Custom Device/Help/HTML Help Source/Status Section.html
+++ b/Source/Custom Device/Help/HTML Help Source/Status Section.html
@@ -28,5 +28,17 @@ or you can open it in Word, edit it, and save it as a .htm or .html file.
 				<li><strong>Description</strong>&#8212;Describes the section.</li>
 			</ul>
 		</p>
+		<p>This section contains the following channels which count the receive (Rx) errors detected in hardware and returned in the status word:
+			<ul>
+				<li><strong>General Protocol Error Count</strong>&#8212;Count of words where a <strong>Protocol Error</strong> detected.</li>
+				<li><strong>Improper Number of Words Error Count</strong>&#8212;Count of errors that occurred because the number of detected words differed from the number of configured words for a message.</li>
+				<li><strong>Manchester Error Count</strong>&#8212;Count of Manchester encoding errors. Manchester encoding requires that each bit has at least one transition and occupies the same time.</li>
+				<li><strong>Monitor Error Count</strong>&#8212;Count of words in which any of the following errors occurred: <strong>General Protocol Error</strong>, <strong>Wrong Sync Error</strong>, <strong>Improper Number of Data Words Error</strong>, <strong>Manchester Error</strong>, <strong>Parity Error</strong>, or <strong>Word Error</strong>.</li>
+				<li><strong>Parity Error Count</strong>&#8212;Count of words where a <strong>Parity Error</strong> detected.</li>
+				<li><strong>Unconfigured Frames Error Count</strong>&#8212;Count of frames received that were not configured in the <strong>hardware configuration file</strong>.</li>
+				<li><strong>Word Error Count</strong>&#8212;Count of messages where a <strong>Word Error</strong> detected.</li>
+				<li><strong>Wrong Sync Error Count</strong>&#8212;Count of words where the <strong>Wrong Sync Error</strong> detected.</li>
+			</ul>
+		</p>
 	</body>
 </html> 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates the source html for the Status Section page to now include descriptions for each status channel.

### Why should this Pull Request be merged?

Status channel descriptions give more context for each error counter, especially those error counters which aggregate more than one specific error type.

Fixes #121 

### What testing has been done?

Built custom device **configuration release** spec successfully. Verified resulting CHM content in System Explorer:
![image](https://user-images.githubusercontent.com/25972098/134368074-a3b8bc8f-e168-4d7a-891f-d3d73907e305.png)
