### PR TITLE
Inline Decoding subVI to workaround build issue that exported extra files and crosslinked files

### DIFF
--- a/Source/Custom Device Support/Ballard MIL-STD-1553 Support.lvproj
+++ b/Source/Custom Device Support/Ballard MIL-STD-1553 Support.lvproj
@@ -844,6 +844,9 @@
 			<Item Name="mscorlib" Type="VI" URL="mscorlib">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
+			<Item Name="NationalInstruments.VeriStand.Internal" Type="Document" URL="NationalInstruments.VeriStand.Internal">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
 			<Item Name="NationalInstruments.VeriStand.SystemDefinitionAPI" Type="Document" URL="NationalInstruments.VeriStand.SystemDefinitionAPI">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Inline Decoding subVI to workaround build issue that exported extra files and crosslinked files

### Why should this Pull Request be merged?

Fixes #88  
Fixes exports such that they are deployable.

### What testing has been done?

Was able to reproduce broken builds locally after resetting repo. Made changes.
Locally built all specs successfully. Deployed from VeriStand and verified loopback. All tests run and passed.
Pulled builds from server (build 9, 10) and verified deployment and behavior.