### PR TITLE
Add file for logging CHM

### DIFF
--- a/Source/Custom Device/Help/HTML Help Source/Logging.html
+++ b/Source/Custom Device/Help/HTML Help Source/Logging.html
@@ -1,0 +1,22 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+	<head>
+		<meta http-equiv="Content-Style-Type" content="text/css">
+		<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
+		<title>Logging</title>
+		<link rel="STYLESHEET" type="text/css" href="css/VSsystemexplorer.css">
+		<script src="common.js" type="text/javascript"></script><script src="js/expandable_tree.js" type="text/javascript"></script>
+		<link rel="STYLESHEET" type="text/css" href="css/expandable_tree.css">
+		<script src="launchhelp.js" type="text/javascript"></script><script src="js/dynamicjumps.js" type="text/javascript"></script>
+	</head>
+	<body>
+		<noscript>
+			<p class="Body">JavaScript is disabled. <a href="veristandmerge.chm::/JavaScript_Disabled.html">Details</a></p>
+			<hr width="100%" noshade>
+		</noscript>
+		<h1>Logging</h1>
+		<p>The Ballard MIL-STD-1553 custom device supports logging transmitted and received messages to a file on the RT target.</p>
+		<p>Enable and configure the log file on this section.</p>
+		<p>Specify which messages to log using the hardware configuration file. Labels with <tt>monitor="true"</tt>, and all labels on channels with <tt>monitorMode="All"</tt> are logged.</p>
+	</body>
+</html>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This adds the html file for the Logging page CHM

### Why should this Pull Request be merged?

This fixes issue #150 

### What testing has been done?

Hand tested in VeriStand
