### PR TITLE
Remove configuration setting docs from error channel help

### DIFF
--- a/Source/Custom Device/Help/HTML Help Source/Error Count.html
+++ b/Source/Custom Device/Help/HTML Help Source/Error Count.html
@@ -22,10 +22,5 @@ or you can open it in Word, edit it, and save it as a .htm or .html file.
 		</noscript>
 		<h1>Error Count</h1>
 		<p>Astronics Ballard MIL-STD 1553 hardware monitors errors for each incoming (Rx) record. Each error counter contains the cumulative count for that specific MIL-STD-1553 error.</p>
-		<p>This channel has the following configuration settings:
-			<ul>
-				<li><strong>Name</strong>&#8212;Specifies the name of the channel in the system definition.</li>
-				<li><strong>Description</strong>&#8212;Describes this <strong>receive time</strong> channel.</li>
-		</p>
 	</body>
 </html>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove documentation related to configuring channels which don't have any configuration.

### Why should this Pull Request be merged?

The `receive time` text caught my eye, and @Karl-G1 and I agreed this text isn't helpful since the channels don't have any configuration options (besides description).

### What testing has been done?

N/A
