### PR TITLE
Build custom device for 2021

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,10 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-List<String> lvVersions = ['2020']
+def lvVersions = [
+  32 : ['2020'],
+  64 : ['2021']
+]
 
-diffPipeline(lvVersions[0])
+diffPipeline(lvVersions)
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)

--- a/Source/Custom Device Support/Ballard MIL-STD-1553 Support.lvproj
+++ b/Source/Custom Device Support/Ballard MIL-STD-1553 Support.lvproj
@@ -707,7 +707,7 @@
 				<Property Name="Destination[2].destName" Type="Str">Top Level</Property>
 				<Property Name="Destination[2].path" Type="Path">../Built/Scripting</Property>
 				<Property Name="DestinationCount" Type="Int">3</Property>
-				<Property Name="Source[0].itemID" Type="Str">{67D88039-3767-4461-BA6A-1D66A732B0C8}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{2E6826BB-AFF0-422A-AE0A-88806846BF2E}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Ballard MIL-STD-1553 Scripting.lvlib</Property>
@@ -717,6 +717,10 @@
 				<Property Name="Source[10].destinationIndex" Type="Int">2</Property>
 				<Property Name="Source[10].itemID" Type="Ref">/My Computer/Palettes/Logging.mnu</Property>
 				<Property Name="Source[10].lvfile" Type="Bool">true</Property>
+				<Property Name="Source[11].destinationIndex" Type="Int">0</Property>
+				<Property Name="Source[11].itemID" Type="Ref">/My Computer/MIL-STD 1553 Import.lvlib/Read Tag Value.vim</Property>
+				<Property Name="Source[11].sourceInclusion" Type="Str">Include</Property>
+				<Property Name="Source[11].type" Type="Str">VI</Property>
 				<Property Name="Source[2].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[2].itemID" Type="Ref">/My Computer/Ballard MIL-STD-1553 Engine.lvlib</Property>
 				<Property Name="Source[2].Library.allowMissingMembers" Type="Bool">true</Property>
@@ -748,7 +752,7 @@
 				<Property Name="Source[9].destinationIndex" Type="Int">2</Property>
 				<Property Name="Source[9].itemID" Type="Ref">/My Computer/Palettes/Remote Terminal.mnu</Property>
 				<Property Name="Source[9].lvfile" Type="Bool">true</Property>
-				<Property Name="SourceCount" Type="Int">11</Property>
+				<Property Name="SourceCount" Type="Int">12</Property>
 			</Item>
 		</Item>
 	</Item>

--- a/build.toml
+++ b/build.toml
@@ -74,7 +74,7 @@ package_output_dir = 'Source\Built'
 
 [package.payload_map]
 'Source\\Built\\Ballard' = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\Ballard'
-'Source\\Built\\Errors' = 'ni-paths-NISHAREDDIR\LabVIEW Run-Time\{veristand_version}\errors\English'
+'Source\\Built\\Errors' = 'ni-paths-NISHAREDDIR{nipaths_64_bitness_suffix}\LabVIEW Run-Time\{veristand_version}\errors\English'
 
 [[package]]
 type = 'nipkg'
@@ -82,6 +82,6 @@ control_file = 'control_scripting'
 package_output_dir = 'Source\Built'
 
 [package.payload_map]
-'Source\\Built\\Scripting' = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\Ballard MIL-STD-1553'
-'Source\\Built\\Scripting Examples' = 'ni-paths-LV{veristand_version}DIR\examples\NI VeriStand Custom Devices\Ballard MIL-STD-1553'
-'Source\\Built\\Errors' = 'ni-paths-LV{veristand_version}DIR\resource\errors\English'
+'Source\\Built\\Scripting' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\vi.lib\addons\VeriStand Custom Device Scripting APIs\Ballard MIL-STD-1553'
+'Source\\Built\\Scripting Examples' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\examples\NI VeriStand Custom Devices\Ballard MIL-STD-1553'
+'Source\\Built\\Errors' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\resource\errors\English'

--- a/control_custom_device
+++ b/control_custom_device
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: Ballard MIL-STD-1553 for VeriStand {veristand_version}
-Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)

--- a/control_scripting
+++ b/control_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: Ballard MIL-STD-1553 LabVIEW Support for VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
 Recommends: ni-ballard-mil-std-1553-veristand-{veristand_version}-support (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables building the custom device for LabVIEW/VeriStand 2021.

In making this change, I also needed to modify the Scripting API build specification in the Support.lvproj. This change is to explicitly include a malleable VI from the Import library that is required to utilize import functionality in the API. This is necessary due to NI bug 1815210 introduced in LabVIEW 2021. This bug causes malleables to be left out of source distribution builds unless they are explicitly included.

### Why should this Pull Request be merged?

VeriStand 2021 needs a 64-bit build of the custom device with LabVIEW 2021 64-bit.

### What testing has been done?

Waiting on PR build.
