### PR TITLE
Enable build for 2023 and use quarterly display version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 
 def lvVersions = [
   32 : ['2020'],
-  64 : ['2021']
+  64 : ['2021', '2023']
 ]
 
 diffPipeline(lvVersions)

--- a/control_custom_device
+++ b/control_custom_device
@@ -10,6 +10,6 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {display_version}
+XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: Ballard MIL-STD-1553 for VeriStand {veristand_version}
 Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)

--- a/control_scripting
+++ b/control_scripting
@@ -10,7 +10,7 @@ Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: {display_version}
+XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: Ballard MIL-STD-1553 LabVIEW Support for VeriStand {veristand_version}
 Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
 Recommends: ni-ballard-mil-std-1553-veristand-{veristand_version}-support (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable build for VeriStand 2023
Use quarterly display version for packages

### Why should this Pull Request be merged?

Allow pre-release testing

### What testing has been done?

Successful branch build and deployment to target
