### PR TITLE
Build for VeriStand 2024

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,11 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
-        - version: '2020'
-          bitness: '32bit'
         - version: '2021'
           bitness: '64bit'
         - version: '2023'
+          bitness: '64bit'
+        - version: '2024'
           bitness: '64bit'
 
       buildSteps:
@@ -65,7 +65,7 @@ stages:
           target: 'Linux x64'
           buildSpec: 'Engine Release'
 
-      releaseVersion: '23.3.0'
+      releaseVersion: '24.0.0'
       buildOutputLocation: 'Source\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\ballard_mil_std_1553'
 

--- a/control_scripting
+++ b/control_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: Ballard MIL-STD-1553 LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 23.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 24.0.0)
 Recommends: ni-ballard-mil-std-1553-veristand-{veristand_version}-support (>= {display_version})

--- a/control_scripting
+++ b/control_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {quarterly_display_version}
 XB-DisplayName: Ballard MIL-STD-1553 LabVIEW Support for VeriStand {veristand_version}
-Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 24.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= {major_version}.0.0)
 Recommends: ni-ballard-mil-std-1553-veristand-{veristand_version}-support (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Build for VeriStand 2024, drop VeriStand 2020.

### Why should this Pull Request be merged?

Needed for the 24.0.0 release.

### What testing has been done?

PR build.