### PR TITLE
Added Conditional Disable Symbol for the three skipped tests

### DIFF
--- a/Source/Custom Device Support/Ballard MIL-STD-1553 Support.lvproj
+++ b/Source/Custom Device Support/Ballard MIL-STD-1553 Support.lvproj
@@ -1,6 +1,6 @@
 ﻿<?xml version='1.0' encoding='UTF-8'?>
 <Project Type="Project" LVVersion="23008000">
-	<Property Name="CCSymbols" Type="Str">DEBUG,False;</Property>
+	<Property Name="CCSymbols" Type="Str">DEBUG,False;DISABLE_ERROR_CASE,TRUE;</Property>
 	<Property Name="NI.LV.All.SourceOnly" Type="Bool">true</Property>
 	<Property Name="NI.Project.Description" Type="Str"></Property>
 	<Item Name="My Computer" Type="My Computer">


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-milStd1553-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Added Conditional Disable Symbol for the three skipped tests mentioned in https://github.com/ni/niveristand-ballard-milStd1553-custom-device/pull/277.


### Why should this Pull Request be merged?

The three test cases failing in [Bug 3096423](https://dev.azure.com/ni/DevCentral/_workitems/edit/3096423) , will pass now.

### What testing has been done?

